### PR TITLE
Graduate a data image of the current state of the database after test failure

### DIFF
--- a/api/Spawn.Demo.WebApi.Tests/Integration/AccountsApiTests.cs
+++ b/api/Spawn.Demo.WebApi.Tests/Integration/AccountsApiTests.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
+using NUnit.Framework.Interfaces;
 
 namespace Spawn.Demo.WebApi.Tests
 {
@@ -46,6 +47,10 @@ namespace Spawn.Demo.WebApi.Tests
         [TearDown]
         public void Teardown()
         {
+            if(TestContext.CurrentContext.Result.Outcome.Status == TestStatus.Failed)
+            {
+              _spawnClient.CreateImageFromCurrentContainerState(_accountsDataContainer, $"account-{TestContext.CurrentContext.Test.ID}", "--tag", SetupFixture.AccountDataImageTag, "--team", "red-gate:sharks");
+            }
             // Don't wait for this task to complete
             // We'll let spawn handle the background deletion
             Task.Run(() => _spawnClient.DeleteDataContainer(_accountsDataContainer));

--- a/api/Spawn.Demo.WebApi.Tests/Integration/AccountsApiTests.cs
+++ b/api/Spawn.Demo.WebApi.Tests/Integration/AccountsApiTests.cs
@@ -49,7 +49,7 @@ namespace Spawn.Demo.WebApi.Tests
         {
             if(TestContext.CurrentContext.Result.Outcome.Status == TestStatus.Failed)
             {
-              _spawnClient.CreateImageFromCurrentContainerState(_accountsDataContainer, $"account-{TestContext.CurrentContext.Test.ID}", "--tag", SetupFixture.AccountDataImageTag, "--team", "red-gate:sharks");
+              _spawnClient.CreateImageFromCurrentContainerState(_accountsDataContainer, $"account-{TestContext.CurrentContext.Test.ID}", SetupFixture.AccountDataImageTag, "--team", "red-gate:sharks");
             }
             // Don't wait for this task to complete
             // We'll let spawn handle the background deletion

--- a/api/Spawn.Demo.WebApi.Tests/Integration/ProjectsApiTests.cs
+++ b/api/Spawn.Demo.WebApi.Tests/Integration/ProjectsApiTests.cs
@@ -61,8 +61,8 @@ namespace Spawn.Demo.WebApi.Tests
         {
             if(TestContext.CurrentContext.Result.Outcome.Status == TestStatus.Failed)
             {
-              _spawnClient.CreateImageFromCurrentContainerState(_todoDataContainer, $"todo-{TestContext.CurrentContext.Test.ID}", "--tag", SetupFixture.TodoDataImageTag, "--team", "red-gate:sharks");
-              _spawnClient.CreateImageFromCurrentContainerState(_accountDataContainer, $"account-{TestContext.CurrentContext.Test.ID}", "--tag", SetupFixture.AccountDataImageTag, "--team", "red-gate:sharks");
+              _spawnClient.CreateImageFromCurrentContainerState(_todoDataContainer, $"todo-{TestContext.CurrentContext.Test.ID}", SetupFixture.TodoDataImageTag, "--team", "red-gate:sharks");
+              _spawnClient.CreateImageFromCurrentContainerState(_accountDataContainer, $"account-{TestContext.CurrentContext.Test.ID}", SetupFixture.AccountDataImageTag, "--team", "red-gate:sharks");
             }
             // Don't wait for these tasks to complete
             // We'll let spawn handle the background deletion

--- a/api/Spawn.Demo.WebApi.Tests/Integration/ProjectsApiTests.cs
+++ b/api/Spawn.Demo.WebApi.Tests/Integration/ProjectsApiTests.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Http;
 using System.Collections.Generic;
 using System;
 using System.Linq;
+using NUnit.Framework.Interfaces;
 
 namespace Spawn.Demo.WebApi.Tests
 {
@@ -58,6 +59,11 @@ namespace Spawn.Demo.WebApi.Tests
         [TearDown]
         public void Teardown()
         {
+            if(TestContext.CurrentContext.Result.Outcome.Status == TestStatus.Failed)
+            {
+              _spawnClient.CreateImageFromCurrentContainerState(_todoDataContainer, $"todo-{TestContext.CurrentContext.Test.ID}", "--tag", SetupFixture.TodoDataImageTag, "--team", "red-gate:sharks");
+              _spawnClient.CreateImageFromCurrentContainerState(_accountDataContainer, $"account-{TestContext.CurrentContext.Test.ID}", "--tag", SetupFixture.AccountDataImageTag, "--team", "red-gate:sharks");
+            }
             // Don't wait for these tasks to complete
             // We'll let spawn handle the background deletion
             Task.Run(() => _spawnClient.DeleteDataContainer(_todoDataContainer));

--- a/api/Spawn.Demo.WebApi.Tests/Integration/SetupFixture.cs
+++ b/api/Spawn.Demo.WebApi.Tests/Integration/SetupFixture.cs
@@ -15,6 +15,8 @@ namespace Spawn.Demo.WebApi.Tests
         private readonly SpawnClient _spawnClient;
         public static string AccountDataImageName = null;
         public static string TodoDataImageName = null;
+        public static string AccountDataImageTag = null;
+        public static string TodoDataImageTag = null;
 
         public SetupFixture()
         {
@@ -48,6 +50,8 @@ namespace Spawn.Demo.WebApi.Tests
 
             AccountDataImageName = $"{accountImageName}:{accountTagName}";
             TodoDataImageName = $"{todoImageName}:{todoTagName}";
+            AccountDataImageTag = accountTagName;
+            TodoDataImageTag = todoTagName;
         }
 
         [OneTimeTearDown]

--- a/api/Spawn.Demo.WebApi.Tests/Integration/TodoApiTests.cs
+++ b/api/Spawn.Demo.WebApi.Tests/Integration/TodoApiTests.cs
@@ -51,7 +51,7 @@ namespace Spawn.Demo.WebApi.Tests
         {
             if(TestContext.CurrentContext.Result.Outcome.Status == TestStatus.Failed)
             {
-              _spawnClient.CreateImageFromCurrentContainerState(_todoDataContainer, $"todo-{TestContext.CurrentContext.Test.ID}", "--tag", SetupFixture.TodoDataImageTag, "--team", "red-gate:sharks");
+              _spawnClient.CreateImageFromCurrentContainerState(_todoDataContainer, $"todo-{TestContext.CurrentContext.Test.ID}", SetupFixture.TodoDataImageTag, "--team", "red-gate:sharks");
             }
             // Don't wait for these tasks to complete
             // We'll let spawn handle the background deletion

--- a/api/Spawn.Demo.WebApi.Tests/Integration/TodoApiTests.cs
+++ b/api/Spawn.Demo.WebApi.Tests/Integration/TodoApiTests.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Http;
 using System.Collections.Generic;
 using System;
 using System.Linq;
+using NUnit.Framework.Interfaces;
 
 namespace Spawn.Demo.WebApi.Tests
 {
@@ -48,6 +49,10 @@ namespace Spawn.Demo.WebApi.Tests
         [TearDown]
         public void Teardown()
         {
+            if(TestContext.CurrentContext.Result.Outcome.Status == TestStatus.Failed)
+            {
+              _spawnClient.CreateImageFromCurrentContainerState(_todoDataContainer, $"todo-{TestContext.CurrentContext.Test.ID}", "--tag", SetupFixture.TodoDataImageTag, "--team", "red-gate:sharks");
+            }
             // Don't wait for these tasks to complete
             // We'll let spawn handle the background deletion
             Task.Run(() => _spawnClient.DeleteDataContainer(_todoDataContainer));

--- a/api/Spawn.Demo.WebApi.Tests/Spawnctl/Spawnctl.cs
+++ b/api/Spawn.Demo.WebApi.Tests/Spawnctl/Spawnctl.cs
@@ -69,6 +69,17 @@ namespace Spawn.Demo.WebApi.Tests.Spawnctl
             }
         }
 
+        public string CreateImageFromCurrentContainerState(string containerIdentifier, string newImageName, params string[] extraArgs)
+        {
+            _logger.WriteLine($"Creating new data image '{newImageName}' from current state of data container '{containerIdentifier}'...");
+            var newRevision = RunSpawnctl("save", "data-container", containerIdentifier, "-q");
+            var args = new List<string> { "graduate", "data-container", containerIdentifier, "--revision", newRevision, "--name", newImageName };
+            args.AddRange(extraArgs);
+            var newImage = RunSpawnctl(args.ToArray());
+            _logger.WriteLine($"Successfully graduated current data container state to new data image '{newImageName}'");
+            return newImage;
+        }
+
         private string GetPgConnString(ConnectionDetails connectionDetails)
         {
             var npgsqlConnStringBuilder = new NpgsqlConnectionStringBuilder()

--- a/api/Spawn.Demo.WebApi.Tests/Spawnctl/Spawnctl.cs
+++ b/api/Spawn.Demo.WebApi.Tests/Spawnctl/Spawnctl.cs
@@ -69,14 +69,14 @@ namespace Spawn.Demo.WebApi.Tests.Spawnctl
             }
         }
 
-        public string CreateImageFromCurrentContainerState(string containerIdentifier, string newImageName, params string[] extraArgs)
+        public string CreateImageFromCurrentContainerState(string containerIdentifier, string newImageName, string tag, params string[] extraArgs)
         {
-            _logger.WriteLine($"Creating new data image '{newImageName}' from current state of data container '{containerIdentifier}'...");
+            _logger.WriteLine($"🛸 Creating new data image '{newImageName}' from current state of data container '{containerIdentifier}'...");
             var newRevision = RunSpawnctl("save", "data-container", containerIdentifier, "-q");
-            var args = new List<string> { "graduate", "data-container", containerIdentifier, "--revision", newRevision, "--name", newImageName };
+            var args = new List<string> { "graduate", "data-container", containerIdentifier, "--revision", newRevision, "--name", newImageName, "--tag", tag };
             args.AddRange(extraArgs);
             var newImage = RunSpawnctl(args.ToArray());
-            _logger.WriteLine($"Successfully graduated current data container state to new data image '{newImageName}'");
+            _logger.WriteLine($"🛸 Successfully graduated current data container state to new data image '{newImageName}:{tag}'");
             return newImage;
         }
 


### PR DESCRIPTION
To aid in test failure debugging and diagnosis, this adds behaviour to snapshot the state of the data container after a failed test and automatically graduate it into an image for manual inspection by a user after test failure.

This will allow users to inspect the state of their database after failures, enabling advanced debugging of the state of failed tests after completion.