### PR TITLE
Various fixes to running the demo in the devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,3 +12,9 @@ RUN curl https://run.spawn.cc/install | sh && ln -s $HOME/.spawnctl/bin/spawnctl
 # Install Flyway
 RUN wget -qO- https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/7.0.2/flyway-commandline-7.0.2-linux-x64.tar.gz | \
  tar xvz && sudo ln -s `pwd`/flyway-7.0.2/flyway /usr/local/bin
+
+# And bash completion
+RUN apt update
+RUN apt install bash-completion
+RUN echo "source /etc/profile.d/bash_completion.sh" >> ~/.bashrc
+RUN echo "source <(spawnctl completion bash)" >> ~/.bashrc

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -36,6 +36,7 @@
       "trace": false,
       "sourceMaps": false,
       "outputCapture": "std",
+      "autoAttachChildProcesses": false,
       "presentation": {
         "hidden": true
       }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
   "files.exclude": {
-  }
+  },
+  "terminal.integrated.fontSize": 16,
 }


### PR DESCRIPTION
We run the demo in the devcontainer, but F5 to start it currently doesn't work - the 3000 service isn't accessible. We fix this and do a couple of other things in the PR

- fix the F5 start up by setting `autoAttachChildProcesses`
- set the bash shell to do spawn auto-completion
- set the font in the terminal to larger size
