### PR TITLE
Use bash for the shell command

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,6 +5,12 @@
       "label": "Create Spawn Data Containers",
       "command": "source ${workspaceRoot}/.env && source ${workspaceRoot}/spawn.sh && validateImagesExist && setupContainers && migrateDatabases",
       "type": "shell",
+      "options": {
+        "shell": {
+          "executable": "bash",
+          "args": ["-c"]
+        }
+      },
       "presentation": {
         "echo": true,
         "reveal": "always",


### PR DESCRIPTION
Sets `bash` explicitly in command options for running a shell task.