### PR TITLE
Use gitpod prebuilds via init tasks to prebuild deps

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -17,3 +17,12 @@ tasks:
 ports:
   - port: 3000
   - port: 5050
+github:
+  prebuilds:
+    master: true
+    branches: false
+    pullRequests: false
+    pullRequestsFromForks: false
+    addCheck: false
+    addComment: true
+    addBadge: false

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,10 +6,10 @@ vscode:
 tasks:
   - name: Run dotnet backend
     command: dotnet run --project ./api/Spawn.Demo.WebApi
-    init: gp sync-await envsetup
+    init: dotnet build ./api/Spawn.Demo.WebApi && gp sync-await envsetup
   - name: Run react frontend
     command: cd client && REACT_APP_SPAWN_DEMO_ENDPOINT=$(gp url 5050) yarn start
-    init: gp sync-await envsetup
+    init: cd client && yarn && gp sync-await envsetup
     openMode: split-right
   - name: Setup environment
     command: bash gitpod-start.sh

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,8 +8,8 @@ tasks:
     command: dotnet run --project ./api/Spawn.Demo.WebApi
     init: dotnet build ./api/Spawn.Demo.WebApi && gp sync-await envsetup
   - name: Run react frontend
-    command: cd client && REACT_APP_SPAWN_DEMO_ENDPOINT=$(gp url 5050) yarn start
-    init: cd client && yarn && gp sync-await envsetup
+    command: REACT_APP_SPAWN_DEMO_ENDPOINT=$(gp url 5050) yarn --cwd client/ start
+    init: yarn --cwd client/ && gp sync-await envsetup
     openMode: split-right
   - name: Setup environment
     command: bash gitpod-start.sh

--- a/gitpod-start.sh
+++ b/gitpod-start.sh
@@ -24,18 +24,6 @@ validateImagesExist
 setupContainers
 migrateDatabases
 
-echo ''
-echo 'Building .NET app...'
-
-dotnet build ./api/Spawn.Demo.WebApi
-
-echo ''
-echo 'Restoring frontend dependencies...'
-
-pushd ./client
-yarn
-popd
-
 echo 'Environment set up successfully!'
 gp sync-done envsetup
 exit


### PR DESCRIPTION
Take advantage of Gitpod's prebuilds feature by moving the build of the backend and frontend into an init task instead of the `gitpod-start.sh` script.